### PR TITLE
try to fix AntUnit tests

### DIFF
--- a/apache-rat-tasks/run-antunit.xml
+++ b/apache-rat-tasks/run-antunit.xml
@@ -30,11 +30,12 @@
     <pathelement location="../apache-rat-core/target/classes"/>
     <pathelement location="../apache-rat-api/target/classes"/>
     <pathelement location="target/test-classes"/>
-    <pathelement location="${user.home}/.m2/repository/org/apache/ant/ant-antunit/1.4/ant-antunit-1.4.jar"/>
-    <pathelement location="${user.home}/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar"/>
-    <pathelement location="${user.home}/.m2/repository/commons-cli/commons-cli/1.3.1/commons-cli-1.3.1.jar"/>
-    <pathelement location="${user.home}/.m2/repository/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar"/>
-    <pathelement location="${user.home}/.m2/repository/commons-io/commons-io/2.2/commons-io-2.2.jar"/>
+    <pathelement location="${user.home}/.m2/repository/org/apache/ant/ant-antunit/1.4.1/ant-antunit-1.4.1.jar"/>
+    <pathelement location="${user.home}/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"/>
+    <pathelement location="${user.home}/.m2/repository/commons-cli/commons-cli/1.5.0/commons-cli-1.3.1.jar"/>
+    <pathelement location="${user.home}/.m2/repository/org/apache/commons/commons-collections4/4.4/commons-collections4-4.4.jar"/>
+    <pathelement location="${user.home}/.m2/repository/commons-io/commons-io/2.11.0/commons-io-2.11.0.jar"/>
+    <pathelement location="${user.home}/.m2/repository/commons-beanutils/commons-beanutils/1.9.4/commons-beanutils-1.9.4.jar"/>
   </path>
   <property name="test.classpath" refid="test-classpath"/>
 

--- a/apache-rat-tasks/src/test/resources/antunit/report-normal-operation.xml
+++ b/apache-rat-tasks/src/test/resources/antunit/report-normal-operation.xml
@@ -55,10 +55,12 @@ SPDX-License-Identifier: Apache-2.0
 		loaderref="testloader" />
 
 	<typedef name="matcher" classname="org.example.Matcher"
-		classpath="${test.classpath}" />
+		classpath="${test.classpath}"
+		loaderref="testloader" />
 
 	<typedef name="matcherBuilder" classname="org.example.MatcherBuilder"
-		classpath="${test.classpath}" />
+		classpath="${test.classpath}"
+		loaderref="testloader" />
 
 	<target name="setUp">
 		<pathconvert dirsep="/" property="file.name">
@@ -99,7 +101,7 @@ SPDX-License-Identifier: Apache-2.0
 			<rat:report>
 				<file file="${ant.file}" />
 			</rat:report>
-<!-- FIXME			<au:assertLogContains text="${expectedOutput}" />-->
+			<au:assertLogContains text="${expectedOutput}" />
 		</target>
 
 		<target name="testWithReportSentToFile" depends="fileReportTest">
@@ -138,7 +140,7 @@ SPDX-License-Identifier: Apache-2.0
 			</rat:license>
 		</rat:report>
 		<au:assertLogDoesntContain text="${expectedOutput}" />
-<!--FIXME		<au:assertLogContains text="!????? ${file.name}" />-->
+		<au:assertLogContains text="!????? ${file.name}" />
 	</target>
 
 		<target name="testWithALUnknownSentToFile" depends="fileReportTest">
@@ -160,33 +162,33 @@ SPDX-License-Identifier: Apache-2.0
 			<assertReportContains text="!????? ${file.name}" />
 		</target>
 
-<!-- FIXME		<target name="testCustomMatcher">-->
-<!-- 			<rat:report useDefaultLicenses="false">-->
-<!--				<file file="${ant.file}" />-->
-<!--				<rat:license-->
-<!--					id="EXMPL"-->
-<!--					name="Yet Another Software License (EXAMPLE) 1.0"-->
-<!--					notes="Interesting License">-->
-<!--					<matcher />-->
-<!--				</rat:license>-->
-<!--			</rat:report>-->
-<!--			<au:assertLogDoesntContain text="${expectedOutput}" />-->
-<!--			<au:assertLogContains text=" EXMPL ${file.name}" />-->
-<!--		</target>-->
+		<target name="testCustomMatcher">
+ 			<rat:report useDefaultLicenses="false">
+				<file file="${ant.file}" />
+				<rat:license
+					id="EXMPL"
+					name="Yet Another Software License (EXAMPLE) 1.0"
+					notes="Interesting License">
+					<matcher />
+				</rat:license>
+			</rat:report>
+			<au:assertLogDoesntContain text="${expectedOutput}" />
+			<au:assertLogContains text=" EXMPL ${file.name}" />
+		</target>
 
-<!-- FIXME		<target name="testCustomMatcherBuilder">-->
-<!--			<rat:report useDefaultLicenses="false">-->
-<!--				<file file="${ant.file}" />-->
-<!--				<rat:license-->
-<!--					id="EXMPL"-->
-<!--					name="Yet Another Software License (EXAMPLE) 1.0"-->
-<!--					notes="Interesting License">-->
-<!--					<matcherBuilder />-->
-<!--				</rat:license>-->
-<!--			</rat:report>-->
-<!--			<au:assertLogDoesntContain text="${expectedOutput}" />-->
-<!--			<au:assertLogContains text=" EXMPL ${file.name}" />-->
-<!--		</target>-->
+		<target name="testCustomMatcherBuilder">
+			<rat:report useDefaultLicenses="false">
+				<file file="${ant.file}" />
+				<rat:license
+					id="EXMPL"
+					name="Yet Another Software License (EXAMPLE) 1.0"
+					notes="Interesting License">
+					<matcherBuilder />
+				</rat:license>
+			</rat:report>
+			<au:assertLogDoesntContain text="${expectedOutput}" />
+			<au:assertLogContains text=" EXMPL ${file.name}" />
+		</target>
 
 		<target name="testInlineCustomMatcher"
 	depends="prepareCustomMatcher">
@@ -200,7 +202,7 @@ SPDX-License-Identifier: Apache-2.0
 				</rat:license>
 			</rat:report>
 			<au:assertLogDoesntContain text="${expectedOutput}" />
-<!-- FIXME			<au:assertLogContains text=" EXMPL ${file.name}" />-->
+			<au:assertLogContains text=" EXMPL ${file.name}" />
 		</target>
 
 <!-- FIXME		<target name="testCustomLicenseSentToFile"-->

--- a/apache-rat-tasks/src/test/resources/antunit/report-normal-operation.xml
+++ b/apache-rat-tasks/src/test/resources/antunit/report-normal-operation.xml
@@ -205,17 +205,22 @@ SPDX-License-Identifier: Apache-2.0
 			<au:assertLogContains text=" EXMPL ${file.name}" />
 		</target>
 
-<!-- FIXME		<target name="testCustomLicenseSentToFile"-->
-<!--			depends="fileReportTest,prepareCustomMatcher">-->
-<!--			<rat:report reportFile="${report.file}">-->
-<!--				<file file="${ant.file}" />-->
-<!--				<rat:myMatcher />-->
-<!--			</rat:report>-->
-<!--			<copy overwrite="true" file="${report.file}" toFile="${reports.dir}/TEST-testCustomLicenseSentToFile.out"/>-->
-<!--			<au:assertLogDoesntContain text="${expectedOutput}" />-->
-<!--			<au:assertLogDoesntContain text=" EXMPL ${file.name}" />-->
-<!--			<assertReportContains text=" EXMPL ${file.name}" />-->
-<!--		</target>-->
+		<target name="testCustomLicenseSentToFile"
+			depends="fileReportTest,prepareCustomMatcher">
+			<rat:report reportFile="${report.file}">
+				<file file="${ant.file}" />
+				<rat:license
+					id="EXMPL"
+					name="Yet Another Software License (EXAMPLE) 1.0"
+					notes="Interesting License">
+					<matcher />
+				</rat:license>
+			</rat:report>
+			<copy overwrite="true" file="${report.file}" toFile="${reports.dir}/TEST-testCustomLicenseSentToFile.out"/>
+			<au:assertLogDoesntContain text="${expectedOutput}" />
+			<au:assertLogDoesntContain text=" EXMPL ${file.name}" />
+			<assertReportContains text=" EXMPL ${file.name}" />
+		</target>
 
 		<target name="testAnyBuild">
 			<rat:report useDefaultLicenses="false">


### PR DESCRIPTION
* made sure run-antunit.xml's dependncies are up to date with RAT
* made sure the custom matcher is loaded via the same classloader as RAT itselt, otherwise its `IHeaderMatcher` is not a `IHeaderMatcher` to RAT when loaded when loaded via different class loaders
* <rat:report> simply doesn't support nested matchers, it only supports nested license elements

Tests still fail when run via Maven but there I'm not the right person to ask. 